### PR TITLE
Adding operator < on Value.

### DIFF
--- a/include/tiny_gltf.h
+++ b/include/tiny_gltf.h
@@ -1751,7 +1751,7 @@ struct LoadImageDataOption {
 // LessThan function for Value, for recursivity
 static bool LessThan(const tinygltf::Value &one, const tinygltf::Value &other) {
   if (one.Type() != other.Type())
-    return one.Type() != other.Type();
+    return one.Type() < other.Type();
   switch (one.Type()) {
     case NULL_TYPE:
       return false;


### PR DESCRIPTION
Useful for ordering or sorting collections that use Value. This was needed to correctly implement material consolidation in open3d::TriangleMesh.